### PR TITLE
free tests! failing tests :(

### DIFF
--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -3,14 +3,15 @@ module Main where
 
 import Test.Hspec
 
-import HigherKind as HigherKind
-import ObjectWithSingleFieldNoTagSingleConstructors as ObjectWithSingleFieldNoTagSingleConstructors
-import ObjectWithSingleFieldTagSingleConstructors as ObjectWithSingleFieldTagSingleConstructors
-import TaggedObjectNoTagSingleConstructors as TaggedObjectNoTagSingleConstructors
-import TaggedObjectTagSingleConstructors as TaggedObjectTagSingleConstructors
-import TwoElemArrayNoTagSingleConstructors as TwoElemArrayNoTagSingleConstructors
-import TwoElemArrayTagSingleConstructors as TwoElemArrayTagSingleConstructors
-import Untagged as Untagged
+import qualified HigherKind as HigherKind
+import qualified Misc as Misc
+import qualified ObjectWithSingleFieldNoTagSingleConstructors as ObjectWithSingleFieldNoTagSingleConstructors
+import qualified ObjectWithSingleFieldTagSingleConstructors as ObjectWithSingleFieldTagSingleConstructors
+import qualified TaggedObjectNoTagSingleConstructors as TaggedObjectNoTagSingleConstructors
+import qualified TaggedObjectTagSingleConstructors as TaggedObjectTagSingleConstructors
+import qualified TwoElemArrayNoTagSingleConstructors as TwoElemArrayNoTagSingleConstructors
+import qualified TwoElemArrayTagSingleConstructors as TwoElemArrayTagSingleConstructors
+import qualified Untagged as Untagged
 
 main = hspec $ do
   ObjectWithSingleFieldTagSingleConstructors.tests
@@ -21,3 +22,4 @@ main = hspec $ do
   TwoElemArrayNoTagSingleConstructors.tests
   Untagged.tests
   HigherKind.tests
+  Misc.tests

--- a/test/Untagged.hs
+++ b/test/Untagged.hs
@@ -53,7 +53,8 @@ declarations = ((getTypeScriptDeclarations (Proxy :: Proxy Unit)) <>
                  (getTypeScriptDeclarations (Proxy :: Proxy OneField)) <>
                  (getTypeScriptDeclarations (Proxy :: Proxy TwoFieldRecordless)) <>
                  (getTypeScriptDeclarations (Proxy :: Proxy TwoField)) <>
-                 (getTypeScriptDeclarations (Proxy :: Proxy TwoConstructor))
+                 (getTypeScriptDeclarations (Proxy :: Proxy TwoConstructor)) <>
+                 (getTypeScriptDeclarations (Proxy :: Proxy MixedNullary))
                )
 
 typesAndValues = [(getTypeScriptType (Proxy :: Proxy Unit) , A.encode Unit)
@@ -63,6 +64,8 @@ typesAndValues = [(getTypeScriptType (Proxy :: Proxy Unit) , A.encode Unit)
                  , (getTypeScriptType (Proxy :: Proxy TwoField) , A.encode $ TwoField 42 "asdf")
                  , (getTypeScriptType (Proxy :: Proxy TwoConstructor) , A.encode $ Con1 "asdf")
                  , (getTypeScriptType (Proxy :: Proxy TwoConstructor) , A.encode $ Con2 "asdf" 42)
+                 , (getTypeScriptType (Proxy :: Proxy MixedNullary) , A.encode $ Normal)
+                 , (getTypeScriptType (Proxy :: Proxy MixedNullary) , A.encode $ Other "asdf")
                  ]
 
 tests = describe "UntaggedValue" $ do


### PR DESCRIPTION
There were a few datatypes in the test files which weren't being included in the `testTypeCheckDeclarations`, so it was easy to extend the test suite without having to write any new code. And these are quite valuable tests, too: they reveal that the library doesn't work with the example datatype `D` presented in the `README`!