### PR TITLE
Add functions to FormatOptions to modify output interface/type names.

### DIFF
--- a/src/Data/Aeson/TypeScript/Formatting.hs
+++ b/src/Data/Aeson/TypeScript/Formatting.hs
@@ -14,7 +14,7 @@ formatTSDeclarations = formatTSDeclarations' defaultFormattingOptions
 -- | Format a single TypeScript declaration. This version accepts a FormattingOptions object in case you want more control over the output.
 formatTSDeclaration :: FormattingOptions -> TSDeclaration -> String
 formatTSDeclaration (FormattingOptions {..}) (TSTypeAlternatives name genericVariables names) =
-  [i|type #{interfaceNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
+  [i|type #{typeNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
   where alternatives = T.intercalate " | " (fmap T.pack names)
 
 formatTSDeclaration (FormattingOptions {..}) (TSInterfaceDeclaration interfaceName genericVariables members) = [i|interface #{modifiedInterfaceName}#{getGenericBrackets genericVariables} {

--- a/src/Data/Aeson/TypeScript/Formatting.hs
+++ b/src/Data/Aeson/TypeScript/Formatting.hs
@@ -13,11 +13,14 @@ formatTSDeclarations = formatTSDeclarations' defaultFormattingOptions
 
 -- | Format a single TypeScript declaration. This version accepts a FormattingOptions object in case you want more control over the output.
 formatTSDeclaration :: FormattingOptions -> TSDeclaration -> String
-formatTSDeclaration (FormattingOptions {numIndentSpaces}) (TSTypeAlternatives name genericVariables names) = [i|type #{name}#{getGenericBrackets genericVariables} = #{alternatives};|]
+formatTSDeclaration (FormattingOptions {..}) (TSTypeAlternatives name genericVariables names) =
+  [i|type #{interfaceNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
   where alternatives = T.intercalate " | " (fmap T.pack names)
-formatTSDeclaration (FormattingOptions {numIndentSpaces}) (TSInterfaceDeclaration interfaceName genericVariables members) = [i|interface #{interfaceName}#{getGenericBrackets genericVariables} {
+
+formatTSDeclaration (FormattingOptions {..}) (TSInterfaceDeclaration interfaceName genericVariables members) = [i|interface #{modifiedInterfaceName}#{getGenericBrackets genericVariables} {
 #{lines}
 }|] where lines = T.intercalate "\n" $ fmap T.pack [(replicate numIndentSpaces ' ') <> formatTSField member <> ";"| member <- members]
+          modifiedInterfaceName = (\(i, name) -> i <> interfaceNameModifier name) . splitAt 1 $ interfaceName
 
 -- | Format a list of TypeScript declarations into a string, suitable for putting directly into a @.d.ts@ file.
 formatTSDeclarations' :: FormattingOptions -> [TSDeclaration] -> String

--- a/src/Data/Aeson/TypeScript/Instances.hs
+++ b/src/Data/Aeson/TypeScript/Instances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, ExistentialQuantification, FlexibleInstances  #-}
+{-# LANGUAGE QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, ExistentialQuantification, FlexibleInstances, OverlappingInstances #-}
 
 -- Note: the OverlappingInstances pragma is only here so the overlapping instances in this file
 -- will work on older GHCs, like GHC 7.8.4

--- a/src/Data/Aeson/TypeScript/Instances.hs
+++ b/src/Data/Aeson/TypeScript/Instances.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, ExistentialQuantification, FlexibleInstances, OverlappingInstances #-}
+{-# LANGUAGE QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, ExistentialQuantification, FlexibleInstances  #-}
 
 -- Note: the OverlappingInstances pragma is only here so the overlapping instances in this file
 -- will work on older GHCs, like GHC 7.8.4

--- a/src/Data/Aeson/TypeScript/Types.hs
+++ b/src/Data/Aeson/TypeScript/Types.hs
@@ -73,12 +73,15 @@ data FormattingOptions = FormattingOptions
   { numIndentSpaces       :: Int
   -- ^ How many spaces to indent TypeScript blocks
   , interfaceNameModifier :: String -> String
-  -- ^ How to modify an output interface or type name
+  -- ^ How to modify an output interface name
+  , typeNameModifier :: String -> String
+  -- ^ How to modify an output type name
   }
 
 defaultFormattingOptions = FormattingOptions
   { numIndentSpaces = 2
   , interfaceNameModifier = id
+  , typeNameModifier = id
   }
 
 -- | Convenience typeclass class you can use to "attach" a set of Aeson encoding options to a type.

--- a/src/Data/Aeson/TypeScript/Types.hs
+++ b/src/Data/Aeson/TypeScript/Types.hs
@@ -69,12 +69,17 @@ instance IsString (TSString a) where
 
 -- * Formatting options
 
-data FormattingOptions = FormattingOptions {
-  numIndentSpaces :: Int
+data FormattingOptions = FormattingOptions
+  { numIndentSpaces       :: Int
   -- ^ How many spaces to indent TypeScript blocks
+  , interfaceNameModifier :: String -> String
+  -- ^ How to modify an output interface or type name
   }
 
-defaultFormattingOptions = FormattingOptions 2
+defaultFormattingOptions = FormattingOptions
+  { numIndentSpaces = 2
+  , interfaceNameModifier = id
+  }
 
 -- | Convenience typeclass class you can use to "attach" a set of Aeson encoding options to a type.
 class HasJSONOptions a where


### PR DESCRIPTION
Aeson provides two functions, `fieldLabelModifier` and `constructorTagModifier` which are used to modify the names of fields and data constructor tags, `aeson-typescript` respects these but gives no control over the ability to modify the names of the interfaces and types it generates.

The main problem this causes happens when you want to generate types for two types from different qualified modules, for example:

```haskell
import qualified Foo
import qualified Bar
import           Data.Aeson ( defaultOptions )

deriveTypeScript defaultOptions ''Foo.Example
deriveTypeScript defaultOptions ''Bar.Example
```

Which will create a file with two duplicate types:

```typescript
// From the first derivation.
type Example = IExample;
interface IExample { ... };

// From the second derivation.
type Example = IExample;
interface IExample { ... }
```

This PR adds two modifier functions similar to aeson's to `FormattingOptions`, adding these gives the ability to modify record type names in any way you need. Either automatically with generics or just manually such as:

```haskell
formatTSDeclaration (FormatOptions 4 (<> "Foo") (<> "Foo")) declaration
```

To produce:

```typescript
// From the first derivation.
type ExampleFoo = IExampleFoo;
interface IExampleFoo { ... };
```