### PR TITLE
Allow th-abstraction 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,6 +110,12 @@ matrix:
     compiler: ": #stack 8.6.4"
     addons: {apt: {packages: [libgmp-dev]}}
 
+  # To test against th-abstraction 0.3, which is not contained in
+  # earlier snapshots:
+  - env: BUILD=stack ARGS="--resolver nightly-2019-06-09"
+    compiler: ": #stack nightly-2019-06-09"
+    addons: {apt: {packages: [libgmp-dev]}}
+
   # Nightly builds are allowed to fail
   - env: BUILD=stack ARGS="--resolver nightly"
     compiler: ": #stack nightly"

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ dependencies:
 - mtl
 - template-haskell
 - text
-- th-abstraction < 0.3
+- th-abstraction < 0.4
 - unordered-containers
 
 library:


### PR DESCRIPTION
`th-abstraction` 0.3 renamed the `datatypeVars` field to `datatypeInstTypes`. This pull request enables usage of the renamed field, guarded by CPP.