### PR TITLE
Expose more stuff and add cabal file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .stack-work/
-aeson-typescript.cabal
 *~
 .dir-locals.el

--- a/aeson-typescript.cabal
+++ b/aeson-typescript.cabal
@@ -1,0 +1,98 @@
+-- This file has been generated from package.yaml by hpack version 0.27.0.
+--
+-- see: https://github.com/sol/hpack
+--
+-- hash: 584dc98efdc24fed1334c7b9416994f4761d75469c68b28194194371c53b30f2
+
+name:           aeson-typescript
+version:        0.2.1.0
+synopsis:       Generate TypeScript definition files from your ADTs
+description:    Please see the README on Github at <https://github.com/codedownio/aeson-typescript#readme>
+category:       Text, Web, JSON
+homepage:       https://github.com/codedownio/aeson-typescript#readme
+bug-reports:    https://github.com/codedownio/aeson-typescript/issues
+author:         Tom McLaughlin
+maintainer:     tom@codedown.io
+copyright:      2018 CodeDown
+license:        BSD3
+license-file:   LICENSE
+tested-with:    GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.2
+build-type:     Simple
+cabal-version:  >= 1.10
+
+extra-source-files:
+    ChangeLog.md
+    README.md
+    test/assets/npm_install.sh
+    test/assets/package.json
+    test/assets/yarn.lock
+    test/assets/yarn_install.sh
+
+source-repository head
+  type: git
+  location: https://github.com/codedownio/aeson-typescript
+
+library
+  exposed-modules:
+      Data.Aeson.TypeScript.TH
+  other-modules:
+      Data.Aeson.TypeScript.Formatting
+      Data.Aeson.TypeScript.Instances
+      Data.Aeson.TypeScript.Types
+      Paths_aeson_typescript
+  hs-source-dirs:
+      src
+  build-depends:
+      aeson
+    , base >=4.7 && <5
+    , containers
+    , interpolate
+    , mtl
+    , template-haskell
+    , text
+    , th-abstraction <0.4
+    , unordered-containers
+  default-language: Haskell2010
+
+test-suite aeson-typescript-test
+  type: exitcode-stdio-1.0
+  main-is: Spec.hs
+  other-modules:
+      HigherKind
+      ObjectWithSingleFieldNoTagSingleConstructors
+      ObjectWithSingleFieldTagSingleConstructors
+      TaggedObjectNoTagSingleConstructors
+      TaggedObjectTagSingleConstructors
+      TestBoilerplate
+      TwoElemArrayNoTagSingleConstructors
+      TwoElemArrayTagSingleConstructors
+      UntaggedNoTagSingleConstructors
+      UntaggedTagSingleConstructors
+      Util
+      Data.Aeson.TypeScript.Formatting
+      Data.Aeson.TypeScript.Instances
+      Data.Aeson.TypeScript.TH
+      Data.Aeson.TypeScript.Types
+      Paths_aeson_typescript
+  hs-source-dirs:
+      test
+      src
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+      aeson
+    , aeson-typescript
+    , base >=4.7 && <5
+    , bytestring
+    , containers
+    , directory
+    , filepath
+    , hspec
+    , interpolate
+    , mtl
+    , process
+    , template-haskell
+    , temporary
+    , text
+    , th-abstraction <0.4
+    , unordered-containers
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                aeson-typescript
-version:             0.2.0.0
+version:             0.2.1.0
 github:              "codedownio/aeson-typescript"
 license:             BSD3
 category:            Text, Web, JSON

--- a/src/Data/Aeson/TypeScript/Instances.hs
+++ b/src/Data/Aeson/TypeScript/Instances.hs
@@ -9,6 +9,7 @@ import qualified Data.Aeson as A
 import Data.Aeson.TypeScript.Types
 import Data.Data
 import Data.HashMap.Strict
+import Data.Map
 import Data.Monoid
 import Data.Set
 import Data.String.Interpolate.IsString
@@ -73,6 +74,9 @@ instance TypeScript A.Value where
   getTypeScriptType _ = "any";
 
 instance (TypeScript a, TypeScript b) => TypeScript (HashMap a b) where
+  getTypeScriptType _ = [i|{[k: #{getTypeScriptType (Proxy :: Proxy a)}]: #{getTypeScriptType (Proxy :: Proxy b)}}|]
+
+instance (TypeScript a, TypeScript b) => TypeScript (Map a b) where
   getTypeScriptType _ = [i|{[k: #{getTypeScriptType (Proxy :: Proxy a)}]: #{getTypeScriptType (Proxy :: Proxy b)}}|]
 
 instance (TypeScript a) => TypeScript (Set a) where

--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -103,7 +103,8 @@ module Data.Aeson.TypeScript.TH (
   -- * The main typeclass
   TypeScript(..),
 
-  TSDeclaration,
+  TSDeclaration(..),
+  TSField(..),
 
   -- * Formatting declarations
   formatTSDeclarations,


### PR DESCRIPTION
Not having a .cabal file checked in breaks the [source-repository-package](https://cabal.readthedocs.io/en/latest/nix-local-build.html#specifying-packages-from-remote-version-control-locations) feature of cabal.project files.