### PR TITLE
Implement support for unwrapUnaryRecords option

### DIFF
--- a/test/ObjectWithSingleFieldUnwrapUnaryRecords.hs
+++ b/test/ObjectWithSingleFieldUnwrapUnaryRecords.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, NamedFieldPuns, KindSignatures #-}
+
+module ObjectWithSingleFieldUnwrapUnaryRecords (tests) where
+
+import Data.Aeson as A
+import Data.Aeson.TH as A
+import Test.Hspec
+import TestBoilerplate
+import Util
+
+$(testDeclarations "ObjectWithSingleField with unwrapUnaryRecords=True" A.defaultOptions {unwrapUnaryRecords = True})
+
+main = hspec tests

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -6,6 +6,7 @@ import Test.Hspec
 import qualified HigherKind
 import qualified ObjectWithSingleFieldNoTagSingleConstructors
 import qualified ObjectWithSingleFieldTagSingleConstructors
+import qualified ObjectWithSingleFieldUnwrapUnaryRecords
 import qualified TaggedObjectNoTagSingleConstructors
 import qualified TaggedObjectTagSingleConstructors
 import qualified TwoElemArrayNoTagSingleConstructors
@@ -16,6 +17,7 @@ import qualified UntaggedTagSingleConstructors
 main = hspec $ do
   ObjectWithSingleFieldTagSingleConstructors.tests
   ObjectWithSingleFieldNoTagSingleConstructors.tests
+  ObjectWithSingleFieldUnwrapUnaryRecords.tests
   TaggedObjectTagSingleConstructors.tests
   TaggedObjectNoTagSingleConstructors.tests
   TwoElemArrayTagSingleConstructors.tests


### PR DESCRIPTION
Respect the unwrapUnaryRecords option. When True, this exports unary records / newtypes as a type alias to the type of the single field within.