### PR TITLE
Support omitNothingFields option

### DIFF
--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -246,9 +246,9 @@ handleConstructor options (DatatypeInfo {..}) genericVariables ci@(ConstructorIn
     stringEncoding = (stringE [i|"#{(constructorTagModifier options) $ getTypeName (constructorName ci)}"|], Nothing)
 
     singleConstructorEncoding = if | constructorVariant ci == NormalConstructor -> tupleEncoding
-                                   | otherwise -> Just $ assembleInterfaceDeclaration (constructorName ci) genericVariables (ListE (getTSFields namesAndTypes))
+                                   | otherwise -> Just $ assembleInterfaceDeclaration (constructorName ci) genericVariables (ListE (getTSFields options namesAndTypes))
 
-    taggedConstructorEncoding = Just $ assembleInterfaceDeclaration (constructorName ci) genericVariables (ListE (tagField ++ getTSFields namesAndTypes))
+    taggedConstructorEncoding = Just $ assembleInterfaceDeclaration (constructorName ci) genericVariables (ListE (tagField ++ getTSFields options namesAndTypes))
 
     -- * Type declaration to use
     interfaceName = getInterfaceName (constructorName ci) <> getGenericBrackets genericVariables
@@ -276,11 +276,19 @@ handleConstructor options (DatatypeInfo {..}) genericVariables ci@(ConstructorIn
     contentsTupleType = getTupleType (constructorFields ci)
 
 -- | Helper for handleConstructor
-getTSFields :: [(String, Type)] -> [Exp]
-getTSFields namesAndTypes = [(AppE (AppE (AppE (ConE 'TSField) (getOptionalAsBoolExp typ))
-                                     (stringE nameString))
-                               (getTypeAsStringExp typ))
-                            | (nameString, typ) <- namesAndTypes]
+getTSFields :: Options -> [(String, Type)] -> [Exp]
+getTSFields options namesAndTypes =
+  [ (AppE (AppE (AppE (ConE 'TSField) optAsBool)
+             (stringE nameString))
+       fieldTyp)
+  | (nameString, typ) <- namesAndTypes
+  , let (fieldTyp, optAsBool) = getFieldType options typ]
+
+getFieldType :: Options -> Type -> (Exp, Exp)
+getFieldType options (AppT (ConT name) t)
+  | not (omitNothingFields options) && name == ''Maybe
+  = (AppE (AppE (VarE 'mappend) (getTypeAsStringExp t)) (stringE " | null"), getOptionalAsBoolExp t)
+getFieldType _ typ = (getTypeAsStringExp typ, getOptionalAsBoolExp typ)
 
 -- | Helper for handleConstructor
 assembleInterfaceDeclaration constructorName genericVariables members = AppE (AppE (AppE (ConE 'TSInterfaceDeclaration) constructorNameExp) genericVariablesExp) members where

--- a/test/NoOmitNothingFields.hs
+++ b/test/NoOmitNothingFields.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE CPP, QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, NamedFieldPuns, KindSignatures #-}
+
+module NoOmitNothingFields (tests) where
+
+import Data.Aeson as A
+import Data.Aeson.TH as A
+import Test.Hspec
+import TestBoilerplate
+import Util
+
+$(testDeclarations "NoOmitNothingFields" (A.defaultOptions {omitNothingFields=False}))
+
+main = hspec tests

--- a/test/OmitNothingFields.hs
+++ b/test/OmitNothingFields.hs
@@ -1,0 +1,13 @@
+{-# LANGUAGE CPP, QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, NamedFieldPuns, KindSignatures #-}
+
+module OmitNothingFields (tests) where
+
+import Data.Aeson as A
+import Data.Aeson.TH as A
+import Test.Hspec
+import TestBoilerplate
+import Util
+
+$(testDeclarations "OmitNothingFields" (A.defaultOptions {omitNothingFields=True}))
+
+main = hspec tests

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,8 @@ import qualified TwoElemArrayNoTagSingleConstructors
 import qualified TwoElemArrayTagSingleConstructors
 import qualified UntaggedNoTagSingleConstructors
 import qualified UntaggedTagSingleConstructors
+import qualified OmitNothingFields
+import qualified NoOmitNothingFields
 
 main = hspec $ do
   ObjectWithSingleFieldTagSingleConstructors.tests
@@ -23,3 +25,5 @@ main = hspec $ do
   UntaggedTagSingleConstructors.tests
   UntaggedNoTagSingleConstructors.tests
   HigherKind.tests
+  OmitNothingFields.tests
+  NoOmitNothingFields.tests

--- a/test/Util.hs
+++ b/test/Util.hs
@@ -70,7 +70,7 @@ testTypeCheckDeclarations tsDeclarations typesAndVals = withSystemTempDirectory 
   writeFile tsFile contents
 
   tsc <- getTSC
-  (code, output, err) <- readProcessWithExitCode tsc ["--noEmit", "--skipLibCheck", "--traceResolution", "--noResolve", tsFile] ""
+  (code, output, err) <- readProcessWithExitCode tsc ["--strict", "--noEmit", "--skipLibCheck", "--traceResolution", "--noResolve", tsFile] ""
 
   when (code /= ExitSuccess) $ do
     putStrLn [i|TSC check failed. File contents were\n\n#{contents}|]


### PR DESCRIPTION
if [omitNothingFields](https://hackage.haskell.org/package/aeson-1.4.5.0/docs/Data-Aeson.html#v:omitNothingFields) is not set, then typescript definition should declare optional fields as possibly `null` instead of `undefined`.

Specifically, for the record
```
data R = R { f :: Maybe Int}
```
we generate, depending on the `omitNothingFields` option, either
```
interface {
  f: int | null;
}
```
or
```
interface {
  f?: int;
}
```