### PR TITLE
feat(nix): allow library to be built and imported using nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,4 @@
+with import <nixpkgs> { config.allowUnfree = true; };
+
+callPackage (import ./package.nix) { mkDerivation = haskellPackages.mkDerivation;
+}

--- a/default.nix
+++ b/default.nix
@@ -2,4 +2,8 @@ let nixpkgs = import <nixpkgs> {};
 in
 with nixpkgs;
 
-callPackage (import ./package.nix) { nixpkgs = nixpkgs; }
+callPackage (import ./package.nix)
+  { callCabal2nix = haskellPackages.callCabal2nix;
+    overrideCabal = haskell.lib.overrideCabal;
+    typescript = nodePackages.typescript;
+  }

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,5 @@
-with import <nixpkgs> { config.allowUnfree = true; };
+let nixpkgs = import <nixpkgs> {};
+in
+with nixpkgs;
 
-callPackage (import ./package.nix) { mkDerivation = haskellPackages.mkDerivation;
-}
+callPackage (import ./package.nix) { nixpkgs = nixpkgs; }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, haskellPackages, nodePackages, stdenv
+}:
+with haskellPackages;
+mkDerivation {
+  pname = "aeson-typescript";
+  version = "0.2.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson base containers interpolate mtl template-haskell text
+    th-abstraction unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base bytestring containers directory filepath hspec
+    interpolate mtl process template-haskell temporary text
+    th-abstraction unordered-containers nodePackages.typescript
+  ];
+  homepage = "https://github.com/codedownio/aeson-typescript#readme";
+  description = "Generate TypeScript definition files from your ADTs";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/package.nix
+++ b/package.nix
@@ -1,9 +1,6 @@
-{ nixpkgs
-}:
+{ callCabal2nix, overrideCabal, typescript }:
 
-with nixpkgs;
-
-let pkg = haskellPackages.callCabal2nix "aeson-typescript" ./. {};
-in haskell.lib.overrideCabal pkg (old: {
-  testHaskellDepends = old.testHaskellDepends ++ [ nodePackages.typescript ];
+let pkg = callCabal2nix "aeson-typescript" ./. {};
+in overrideCabal pkg (old: {
+  testHaskellDepends = old.testHaskellDepends ++ [ typescript ];
 })

--- a/package.nix
+++ b/package.nix
@@ -1,20 +1,9 @@
-{ mkDerivation, haskellPackages, nodePackages, stdenv
+{ nixpkgs
 }:
-with haskellPackages;
-mkDerivation {
-  pname = "aeson-typescript";
-  version = "0.2.0.0";
-  src = ./.;
-  libraryHaskellDepends = [
-    aeson base containers interpolate mtl template-haskell text
-    th-abstraction unordered-containers
-  ];
-  testHaskellDepends = [
-    aeson base bytestring containers directory filepath hspec
-    interpolate mtl process template-haskell temporary text
-    th-abstraction unordered-containers nodePackages.typescript
-  ];
-  homepage = "https://github.com/codedownio/aeson-typescript#readme";
-  description = "Generate TypeScript definition files from your ADTs";
-  license = stdenv.lib.licenses.bsd3;
-}
+
+with nixpkgs;
+
+let pkg = haskellPackages.callCabal2nix "aeson-typescript" ./. {};
+in haskell.lib.overrideCabal pkg (old: {
+  testHaskellDepends = old.testHaskellDepends ++ [ nodePackages.typescript ];
+})

--- a/test/Util.hs
+++ b/test/Util.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, NamedFieldPuns #-}
+{-# LANGUAGE CPP, QuasiQuotes, OverloadedStrings, TemplateHaskell, RecordWildCards, ScopedTypeVariables, NamedFieldPuns, LambdaCase #-}
 
 module Util where
 
@@ -30,9 +30,12 @@ getTSC = do
   case isCI of
     True -> do
       return "tsc" -- Assume it's set up on the path
-    False -> do
-      ensureTSCExists
-      return localTSC
+    False ->
+      findExecutable "tsc" >>= \case
+        Just tsc -> pure tsc
+        Nothing -> do
+         ensureTSCExists
+         return localTSC
 
 testTypeCheck :: forall a. (TypeScript a, ToJSON a) => a -> IO ()
 testTypeCheck obj = withSystemTempDirectory "typescript_test" $ \folder -> do


### PR DESCRIPTION
In trying to evaluate your library the dependency on the `tsc` typescript compiler has been making it difficult to import it.
Our build system uses `nix` which runs in an isolated environment where any build dependencies must be explicitly defined.

This PR provides `nix` files to make it easier for the package to be imported.

If someone wants to build the project they can run `nix-build .` which will evaluate `default.nix`.

If someone wants to import the package into their build pipeline they can use the `package.nix` and provide their own definitions for arguments required.

For example this is how your library would be incorporated into someone elses `nix` build:

```
with import ../nixpkgs {};

let aeson-typescript
  = let src = 
       fetchFromGitHub
         { owner = "codedownio";
           repo = "aeson-typescript";
           rev = "fcf4f6608b6aacb0f69b40fb881400353ea07070";
           sha256 = "0rwg3gb7dhvsnzl8wqdfwafymnbl61frl98sz55c527a12zicq51";
         };
       in 
         callPackage (import "${src}/package.nix")
            { callCabal2nix = self.callCabal2nix;
               overrideCabal = haskell.lib.overrideCabal;
               typescript = nodePackages.typescript;
             };
```