### PR TITLE
Update th-abstraction dependency version to <0.5

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,4 @@
 # Changelog for aeson-typescript
 
 ## Unreleased changes
+* Update th-abstraction dependency to < 0.5 to support working with newer Stack lts.

--- a/aeson-typescript.cabal
+++ b/aeson-typescript.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: c5f3990cf145c3739268d2bf2869bd68dbb2c4272a47ae4d8d61dd16d51a37e4
 
 name:           aeson-typescript
-version:        0.2.0.0
+version:        0.2.0.1
 synopsis:       Generate TypeScript definition files from your ADTs
 description:    Please see the README on Github at <https://github.com/codedownio/aeson-typescript#readme>
 category:       Text, Web, JSON
@@ -53,7 +53,7 @@ library
     , mtl
     , template-haskell
     , text
-    , th-abstraction <0.4
+    , th-abstraction <0.5
     , unordered-containers
   default-language: Haskell2010
 
@@ -106,6 +106,6 @@ test-suite aeson-typescript-test
     , template-haskell
     , temporary
     , text
-    , th-abstraction <0.4
+    , th-abstraction <0.5
     , unordered-containers
   default-language: Haskell2010


### PR DESCRIPTION
Stack lts-17.0 upgraded th-abstraction from 0.3.2.0 to 0.4.2.0
This commit updates the package dependency on th-abstraction to
be less than 0.5.