### PR TITLE
Allow to export types easily

### DIFF
--- a/src/Data/Aeson/TypeScript/Formatting.hs
+++ b/src/Data/Aeson/TypeScript/Formatting.hs
@@ -10,7 +10,7 @@ import qualified Data.Text as T
 import Data.Monoid
 #endif
 
-       
+
 -- | Same as 'formatTSDeclarations'', but uses default formatting options.
 formatTSDeclarations :: [TSDeclaration] -> String
 formatTSDeclarations = formatTSDeclarations' defaultFormattingOptions
@@ -18,16 +18,21 @@ formatTSDeclarations = formatTSDeclarations' defaultFormattingOptions
 -- | Format a single TypeScript declaration. This version accepts a FormattingOptions object in case you want more control over the output.
 formatTSDeclaration :: FormattingOptions -> TSDeclaration -> String
 formatTSDeclaration (FormattingOptions {..}) (TSTypeAlternatives name genericVariables names) =
-  [i|type #{typeNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
+  [i|#{exportPrefix exportMode}type #{typeNameModifier name}#{getGenericBrackets genericVariables} = #{alternatives};|]
   where alternatives = T.intercalate " | " (fmap T.pack names)
 
+
 formatTSDeclaration (FormattingOptions {..}) (TSInterfaceDeclaration interfaceName genericVariables members) =
-  [i|interface #{modifiedInterfaceName}#{getGenericBrackets genericVariables} {
+  [i|#{exportPrefix exportMode}interface #{modifiedInterfaceName}#{getGenericBrackets genericVariables} {
 #{ls}
 }|] where ls = T.intercalate "\n" $ fmap T.pack [(replicate numIndentSpaces ' ') <> formatTSField member <> ";"| member <- members]
           modifiedInterfaceName = (\(li, name) -> li <> interfaceNameModifier name) . splitAt 1 $ interfaceName
 
 formatTSDeclaration (FormattingOptions {..}) (TSRawDeclaration text) = text
+
+exportPrefix :: ExportMode -> String
+exportPrefix ExportEach = "export "
+exportPrefix ExportNone = ""
 
 -- | Format a list of TypeScript declarations into a string, suitable for putting directly into a @.d.ts@ file.
 formatTSDeclarations' :: FormattingOptions -> [TSDeclaration] -> String

--- a/src/Data/Aeson/TypeScript/Types.hs
+++ b/src/Data/Aeson/TypeScript/Types.hs
@@ -58,7 +58,7 @@ class (Typeable a) => TypeScript a where
   isGenericVariable :: Proxy a -> Bool
   -- ^ Special flag to indicate whether this type corresponds to a template variable.
   isGenericVariable _ = False
-    
+
 -- | An existential wrapper for any TypeScript instance.
 data TSType = forall a. (Typeable a, TypeScript a) => TSType { unTSType :: Proxy a }
 
@@ -91,6 +91,12 @@ instance IsString (TSString a) where
 
 -- * Formatting options
 
+data ExportMode =
+  ExportEach
+  -- ^ Prefix every declaration with the "export" keyword (suitable for putting in a TypeScripe module)
+  | ExportNone
+  -- ^ No exporting (suitable for putting in a .d.ts file)
+
 data FormattingOptions = FormattingOptions
   { numIndentSpaces       :: Int
   -- ^ How many spaces to indent TypeScript blocks
@@ -98,6 +104,8 @@ data FormattingOptions = FormattingOptions
   -- ^ Function applied to generated interface names
   , typeNameModifier :: String -> String
   -- ^ Function applied to generated type names
+  , exportMode :: ExportMode
+  -- ^ Prefix the generated types with "export" if set to 'True'.
   }
 
 defaultFormattingOptions :: FormattingOptions
@@ -105,6 +113,7 @@ defaultFormattingOptions = FormattingOptions
   { numIndentSpaces = 2
   , interfaceNameModifier = id
   , typeNameModifier = id
+  , exportMode = ExportNone
   }
 
 -- | Convenience typeclass class you can use to "attach" a set of Aeson encoding options to a type.
@@ -136,7 +145,7 @@ instance TypeScript T9 where getTypeScriptType _ = "T9"; isGenericVariable _ = T
 instance TypeScript T10 where getTypeScriptType _ = "T10"; isGenericVariable _ = True
 
 allStarConstructors :: [Type]
-allStarConstructors = [ConT ''T1, ConT ''T2, ConT ''T3, ConT ''T4, ConT ''T5, ConT ''T6, ConT ''T7, ConT ''T8, ConT ''T9, ConT ''T10]                 
+allStarConstructors = [ConT ''T1, ConT ''T2, ConT ''T3, ConT ''T4, ConT ''T5, ConT ''T6, ConT ''T7, ConT ''T8, ConT ''T9, ConT ''T10]
 
 allStarConstructors' :: [Name]
 allStarConstructors' = [''T1, ''T2, ''T3, ''T4, ''T5, ''T6, ''T7, ''T8, ''T9, ''T10]


### PR DESCRIPTION
Hi!

I'd need to generate some types for a typescript module, however, there's currently no way to export the generated types. 

#17, added this feature, however, the PR seems to have stalled by now. This PR is just a cherry pick of 13822f06e45b632446bf6e9b6e8368c060e159b5 rebased on the current master. I took the liberty to add a tiny bit of documentation.

```
Allow to export types easily

In some cases, we'd like to use the generated types in a typescript
module instead of a declaration file. When used in a module, the types
need to be explicitely exported to be re-used elsewhere.

Adding a new exportTypes FormattingOption in charge of prefixing the
generated types with "export".
```