### PR TITLE
Export `defaultFormattingOptions`.

### DIFF
--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -126,6 +126,7 @@ module Data.Aeson.TypeScript.TH (
   , formatTSDeclarations'
   , formatTSDeclaration
   , FormattingOptions(..)
+  , defaultFormattingOptions
   , SumTypeFormat(..)
   , ExportMode(..)
 


### PR DESCRIPTION
No point having a default when the user cannot access to override it! Without this, you cannot write code like

```haskell
... = defaultFormattingOptions{ exportMode = ExportEach }
```

This was forgotten in PR #22 when extracting it from PR #17.

Similar to PR #23.

CC @bitonic 