### PR TITLE
Fix Typescript instance for KeyMap

### DIFF
--- a/src/Data/Aeson/TypeScript/Instances.hs
+++ b/src/Data/Aeson/TypeScript/Instances.hs
@@ -136,7 +136,7 @@ instance (TypeScript a, TypeScript b) => TypeScript (HashMap a b) where
 
 #if MIN_VERSION_aeson(2,0,0)
 instance (TypeScript a) => TypeScript (A.KeyMap a) where
-  getTypeScriptType _ = [i|{[k]?: #{getTypeScriptType (Proxy :: Proxy a)}}|]
+  getTypeScriptType _ = [i|{[k: string]: #{getTypeScriptType (Proxy :: Proxy a)}}|]
   getParentTypes _ = L.nub [TSType (Proxy :: Proxy a)]
 #endif
 


### PR DESCRIPTION
This PR makes `KeyMap a` generate the same type as `HashMap Text a`, so that the old and new Aeson representations of an Object have the same typescript type.

My context is that I have an Object type, and with `aeson-2` and `aeson-typescript-0.4.1.0`, the generated typescript is:

```
{[k]?: any}
```

The typescript compiler fails with an error.

```
TS1170: A computed property name in a type literal must refer to an expression whose type is a literal type or a 'unique symbol' type.
TS2304: Cannot find name 'k'.
```

The type that I actually want is

```
{[k: string]: any}
```

This used to be the generated type using old versions of `aeson` and `aeson-typescript`.
