### PR TITLE
README: fix getTypeScriptDeclarations name

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $(deriveTypeScript (defaultOptions {fieldLabelModifier = drop 4, constructorTagM
 Now we can use the newly created instances.
 
 ```haskell
->>> putStrLn $ formatTSDeclarations $ getTypeScriptDeclaration (Proxy :: Proxy (D T))
+>>> putStrLn $ formatTSDeclarations $ getTypeScriptDeclarations (Proxy :: Proxy (D T))
 
 type D<T> = "nullary" | IUnary<T> | IProduct<T> | IRecord<T>;
 


### PR DESCRIPTION
The function was renamed in https://github.com/codedownio/aeson-typescript/commit/a8ae5934450694ac950a72350e31ab49aa3b72f9