### PR TITLE
Export type variables T4 through T10

### DIFF
--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -137,6 +137,13 @@ module Data.Aeson.TypeScript.TH (
   , T1(..)
   , T2(..)
   , T3(..)
+  , T4(..)
+  , T5(..)
+  , T6(..)
+  , T7(..)
+  , T8(..)
+  , T9(..)
+  , T10(..)
 
   , module Data.Aeson.TypeScript.Instances
   ) where


### PR DESCRIPTION
I would like to generate types with 4 or more type variables, but for some reason the T4..T10 types/constructors aren't exported. I realize that it's possible to define my own type variables, but I couldn't think of a good reason why these shouldn't be exported.