### PR TITLE
test: try to replicate issue with Maybe in multi-field tuple

### DIFF
--- a/src/Data/Aeson/TypeScript/TH.hs
+++ b/src/Data/Aeson/TypeScript/TH.hs
@@ -308,10 +308,19 @@ handleConstructor (ExtraTypeScriptOptions {..}) options (DatatypeInfo {..}) gene
     interfaceName = "I" <> (lastNameComponent' $ constructorName ci)
 
     tupleEncoding = do
-      let typ = contentsTupleTypeSubstituted genericVariables ci
-      stringExp <- lift $ case typ of
-        (AppT (ConT name) t) | name == ''Maybe -> [|$(getTypeAsStringExp t) <> " | null"|]
-        _ -> getTypeAsStringExp typ
+      let fields = constructorFields ci
+      stringExp <- lift $ case fields of
+        [] -> [|"void[]"|]
+        [x] -> case mapType genericVariables x of
+          (AppT (ConT name) t) | name == ''Maybe -> [|$(getTypeAsStringExp t) <> " | null"|]
+          mappedType -> getTypeAsStringExp mappedType
+        xs -> do
+          -- Process each field individually to handle Maybe types
+          fieldStrings <- forM (fmap (mapType genericVariables) xs) $ \fieldType -> case fieldType of
+            (AppT (ConT name) t) | name == ''Maybe -> [|$(getTypeAsStringExp t) <> " | null"|]
+            _ -> getTypeAsStringExp fieldType
+          let fieldExps = map return fieldStrings
+          [|"[" <> $(foldr1 (\a b -> [|$a <> ", " <> $b|]) fieldExps) <> "]"|]
 
       lift [|TSTypeAlternatives $(TH.stringE interfaceName)
                                 $(genericVariablesListExpr True genericVariables)

--- a/test/Basic.hs
+++ b/test/Basic.hs
@@ -4,6 +4,7 @@ module Basic (tests) where
 import Data.Aeson as A
 import Data.Aeson.TypeScript.TH
 import Data.Aeson.TypeScript.Types
+import Data.List.NonEmpty (NonEmpty)
 import Data.Proxy
 import Data.String.Interpolate
 import Prelude hiding (Double)
@@ -22,6 +23,21 @@ deriveTypeScript A.defaultOptions ''Test1
 
 data Test2 = Test2 String [Int] (Maybe String)
 deriveTypeScript A.defaultOptions ''Test2
+
+-- Test case for Maybe types in multi-field tuples
+data PromptKey = PromptKey String deriving (Eq, Show)
+
+$(deriveTypeScript A.defaultOptions ''PromptKey)
+
+newtype ExtraInputPrompt = ExtraInputPrompt String deriving (Eq, Show)
+
+$(deriveTypeScript A.defaultOptions ''ExtraInputPrompt)
+
+data WidgetActionPayload
+  = InfoRequest String [PromptKey] (Maybe (NonEmpty ExtraInputPrompt))
+  deriving (Eq, Show)
+
+$(deriveTypeScript A.defaultOptions ''WidgetActionPayload)
 
 tests :: SpecWith ()
 tests = describe "Basic tests" $ do
@@ -49,6 +65,12 @@ tests = describe "Basic tests" $ do
         , TSTypeAlternatives "ITest2" [] ["[string, number[], string | null]"] Nothing
         ])
 
+    it [i|WidgetActionPayload tuple includes null for Maybe list|] $ do
+      (getTypeScriptDeclarations (Proxy :: Proxy WidgetActionPayload))
+        `shouldBe` ( [ TSTypeAlternatives "WidgetActionPayload" [] ["IInfoRequest"] Nothing,
+                       TSTypeAlternatives "IInfoRequest" [] ["[string, PromptKey[], ExtraInputPrompt[] | null]"] Nothing
+                     ]
+                   )
 
 main :: IO ()
 main = hspec tests

--- a/test/Basic.hs
+++ b/test/Basic.hs
@@ -20,6 +20,9 @@ $(deriveTypeScript (A.defaultOptions { A.tagSingleConstructors = True
 data Test1 = Test1 (Maybe Int)
 deriveTypeScript A.defaultOptions ''Test1
 
+data Test2 = Test2 String [Int] (Maybe String)
+deriveTypeScript A.defaultOptions ''Test2
+
 tests :: SpecWith ()
 tests = describe "Basic tests" $ do
   describe "tagSingleConstructors and constructorTagModifier" $ do
@@ -38,6 +41,12 @@ tests = describe "Basic tests" $ do
       (getTypeScriptDeclarations (Proxy :: Proxy Test1)) `shouldBe` ([
         TSTypeAlternatives "Test1" [] ["ITest1"] Nothing
         , TSTypeAlternatives "ITest1" [] ["number | null"] Nothing
+        ])
+
+    it [i|Maybe in multi-field tuple includes null option|] $ do
+      (getTypeScriptDeclarations (Proxy :: Proxy Test2)) `shouldBe` ([
+        TSTypeAlternatives "Test2" [] ["ITest2"] Nothing
+        , TSTypeAlternatives "ITest2" [] ["[string, number[], string | null]"] Nothing
         ])
 
 


### PR DESCRIPTION
Relates to: https://github.com/codedownio/aeson-typescript/issues/51

```sh
stack test --stack-yaml stack-9.4.8.yaml
```

```hs
Failures:

  test/Generic.hs:68:76: 
  1) Generic instances TestMaybeTuple should handle Maybe in tuples correctly
       expected: [TSTypeAlternatives {
                   typeName = "IConWithMaybe",
                   typeGenericVariables = [],
                   alternativeTypes = ["[string, number[], string[]]"],
                   typeDoc = Nothing
                 }, TSTypeAlternatives {
                   typeName = "ISimpleConstructor",
                   typeGenericVariables = [],
                   alternativeTypes = ["string"],
                   typeDoc = Nothing
                 }, TSInterfaceDeclaration {
                   interfaceName = "IConWithMaybe",
                   interfaceGenericVariables = [],
                   interfaceMembers = [TSField {
                 @@ 4 lines omitted @@
                 }, TSField {
                   fieldOptional = False,
                   fieldName = "contents",
                   fieldType = "IConWithMaybe",
                   fieldDoc = Nothing
                 }],
                   interfaceDoc = Nothing
                 @@ 21 lines omitted @@
                 
        but got: [TSInterfaceDeclaration {
                   interfaceName = "IConWithMaybe",
                   interfaceGenericVariables = [],
                   interfaceMembers = [TSField {
                 @@ 4 lines omitted @@
                 }, TSField {
                   fieldOptional = False,
                   fieldName = "contents",
                   fieldType = "[string, number[], string[]]",
                   fieldDoc = Nothing
                 }],
                   interfaceDoc = Nothing
                 @@ 21 lines omitted @@
```