### PR TITLE
revert 0cf43e7 & partially revert 300d44c

### DIFF
--- a/src/Data/Aeson/TypeScript/Instances.hs
+++ b/src/Data/Aeson/TypeScript/Instances.hs
@@ -160,7 +160,7 @@ instance (TypeScript a, TypeScript b, A.ToJSONKey a) => TypeScript (Map a b) whe
     let k = getTypeScriptKeyType @a Proxy
         v = getTypeScriptType @b Proxy
     in const $ case A.toJSONKey @a of
-      A.ToJSONKeyText {} -> "{[k in " <> k <> "]: " <> v <> "}"
+      A.ToJSONKeyText {} -> "{[k in " <> k <> "]?: " <> v <> "}"
       A.ToJSONKeyValue {} -> getTypeScriptType @[(a, b)] Proxy
   getParentTypes = const $ L.nub [TSType @a Proxy, TSType @b Proxy]
 

--- a/test/Generic.hs
+++ b/test/Generic.hs
@@ -53,7 +53,7 @@ tests = describe "Generic instances" $ do
 
   it [i|Complex4 makes the declaration and types correctly|] $ do
     (getTypeScriptDeclarationsRecursively (Proxy :: Proxy (Complex4 String))) `shouldBe` [
-      TSInterfaceDeclaration "IProduct4" ["T"] [TSField False "record4" "{[k in string]: T}" Nothing] Nothing
+      TSInterfaceDeclaration "IProduct4" ["T"] [TSField False "record4" "{[k in string]?: T}" Nothing] Nothing
       ,TSTypeAlternatives "Complex4" ["T"] ["IProduct4<T>"] Nothing
       ]
 


### PR DESCRIPTION
## description

these changes provide instances for `Data.Map` that generate total maps in TypeScript, which isn't correct behavior (`Data.Map` cannot be total).

closes https://github.com/codedownio/aeson-typescript/issues/55