### PR TITLE
fix(exports): ensure TSAlternativeType is exported too

### DIFF
--- a/src/Data/Aeson/TypeScript/Internal.hs
+++ b/src/Data/Aeson/TypeScript/Internal.hs
@@ -4,6 +4,7 @@
 module Data.Aeson.TypeScript.Internal (
   TSDeclaration(..)
   , TSField(..)
+  , TSAlternativeType(..)
   ) where
 
 import Data.Aeson.TypeScript.Types


### PR DESCRIPTION
Fixes gap in exports: https://github.com/codedownio/aeson-typescript/issues/59